### PR TITLE
Removed navbar from homepage

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def render_navbar?
+    !(controller_name == 'pages' && action_name == 'home')
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,10 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body><%= render "shared/navbar" %>
+  <body>
+  <% if render_navbar? %>
+    <%= render "shared/navbar" %>
+  <% end %>
 <%= render "shared/flashes" %>
 
     <%= yield %>


### PR DESCRIPTION
Removed the navbar from the homepage. 

We'll need to add a logout button and increase the size of the components on the page to make it look nicer. 