### PR TITLE
Shopping list now linked to pantry not user and added to navbar

### DIFF
--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -1,6 +1,10 @@
 class ShoppingListsController < ApplicationController
   before_action :set_shopping_list, only: [:index, :create]
 
+  def index
+    @recipe_ingredient = RecipeIngredient.new
+  end
+
   def new
     @recipe_ingredient = RecipeIngredient.new
   end
@@ -11,15 +15,14 @@ class ShoppingListsController < ApplicationController
     if @recipe_ingredient.save
       redirect_to shopping_lists_path, notice: "Item added successfully"
     else
-      puts @recipe_ingredient.errors.full_messages
-      render :new
+      render :index
     end
   end
 
   private
 
   def set_shopping_list
-    @shopping_list = current_user.shopping_list
+    @shopping_list = current_user.pantry.shopping_list || current_user.pantry.create_shopping_list
   end
 
   def recipe_ingredient_params

--- a/app/models/pantry.rb
+++ b/app/models/pantry.rb
@@ -1,4 +1,5 @@
 class Pantry < ApplicationRecord
   has_many :users
   has_many :ingredients
+  has_one :shopping_list
 end

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -1,4 +1,4 @@
 class ShoppingList < ApplicationRecord
-  belongs_to :user
+  belongs_to :pantry
   has_many :recipe_ingredients
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,13 +5,12 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  belongs_to :pantry, optional: true
-  has_one :shopping_list, dependent: :destroy
-  after_create :create_shopping_list
-  validates :name, presence: true
+  belongs_to :pantry
+  has_many :recipes
 
-private
-  def create_shopping_list
-    self.create_shopping_list!
+  def shopping_list
+    pantry.shopping_list
   end
+
+  validates :name, presence: true
 end

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -2,7 +2,7 @@
   <%= link_to ingredients_path, class: "nav-icon" do %>
     <span class="material-icons nav-font">kitchen</span>
   <% end %>
-  <%= link_to "#", class: "nav-icon" do %>
+  <%= link_to shopping_lists_path, class: "nav-icon" do %>
     <span class="material-icons nav-font">shopping_cart</span>
   <% end %>
   <button class="nav-icon-add">

--- a/app/views/shopping_lists/index.html.erb
+++ b/app/views/shopping_lists/index.html.erb
@@ -1,6 +1,6 @@
 <h1><%= current_user.name %>'s Shopping List</h1>
-
-<% if @shopping_list.recipe_ingredients.any? %>
+<%= link_to 'Add Item', new_shopping_list_path %>
+<% if @shopping_list&.recipe_ingredients&.any? %>
   <ul>
     <% @shopping_list.recipe_ingredients.each do |ingredient| %>
       <li><%= ingredient.name %> - <%= ingredient.amount %> <%= ingredient.unit %></li>
@@ -9,5 +9,3 @@
 <% else %>
   <p>No items in your shopping list.</p>
 <% end %>
-
-<%= link_to 'Add Item', new_shopping_list_path %>

--- a/db/migrate/20240807155243_add_shopping_cart_pantry_link.rb
+++ b/db/migrate/20240807155243_add_shopping_cart_pantry_link.rb
@@ -1,0 +1,6 @@
+class AddShoppingCartPantryLink < ActiveRecord::Migration[7.1]
+  def change
+    remove_reference :shopping_lists, :user, foreign_key: true
+    add_reference :shopping_lists, :pantry, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_06_120501) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_07_155243) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -66,10 +66,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_06_120501) do
   end
 
   create_table "shopping_lists", force: :cascade do |t|
-    t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_shopping_lists_on_user_id"
+    t.bigint "pantry_id"
+    t.index ["pantry_id"], name: "index_shopping_lists_on_pantry_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -94,6 +94,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_06_120501) do
   add_foreign_key "recipe_ingredients", "recipes"
   add_foreign_key "recipe_ingredients", "shopping_lists"
   add_foreign_key "recipes", "users"
-  add_foreign_key "shopping_lists", "users"
+  add_foreign_key "shopping_lists", "pantries"
   add_foreign_key "users", "pantries"
 end


### PR DESCRIPTION
The shopping list now references pantry instead of user. If a user signs up with a linked pantry, the shopping list for that user will be set as the shopping list of that pantry.

If a user signs up with a new pantry, a shopping list will be created for that pantry (and therefore for the user). 

I tried with two accounts sharing a pantry and shopping list together. 

Also added the link to the shopping list to the navbar. 

Hope everything looks good! 