### PR TITLE
The close button added to the navbar. Some css changes for iPhone.

### DIFF
--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -4,6 +4,7 @@
   padding: 8px;
   display: flex;
   flex-direction: column;
+  padding-top:20px;
 }
 
 .form-row {

--- a/app/assets/stylesheets/components/_navigation.scss
+++ b/app/assets/stylesheets/components/_navigation.scss
@@ -41,6 +41,7 @@
 .navigation .nav-icon-add {
   position:relative;
   top: -15px;
+  padding-top: 5px;
 }
 
 .nav-font-add {
@@ -64,4 +65,15 @@
   white-space: nowrap;
   //background-color: $ft-light-green;
   border: 0;
+}
+
+// close-button
+.close-icon {
+  text-decoration: none;
+  position: absolute;
+  top: 5;
+  right: 0;
+  border-style: none;
+  margin-bottom: 5px;
+  font-size: 20px;
 }

--- a/app/assets/stylesheets/components/_pantry_card.scss
+++ b/app/assets/stylesheets/components/_pantry_card.scss
@@ -3,7 +3,7 @@
 .card{
   padding:5px 12px;
   background-color: white;
-  border: none;
+  // border: none;
   margin: 4px;
   border-radius: 16px;
   position: relative;
@@ -25,7 +25,7 @@
 
 .edit-icon{
   position: absolute;
-  right: 16px;
+  right: 5px;
   top: 50%;
   transform: translateY(-50%);
   background: none;

--- a/app/assets/stylesheets/pages/_styles.scss
+++ b/app/assets/stylesheets/pages/_styles.scss
@@ -9,3 +9,9 @@ h2 {
 h3 {
   font-size: 32px;
 }
+
+button {
+  background-color: transparent;
+  text-decoration: none;
+  color: $ft-black;
+}

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -2,6 +2,9 @@
 <div class="navigation-form" data-controller="toggler">
   <%# form start %>
   <div data-toggler-target="form" class="d-none">
+  <button class="close-icon" data-action="toggler#toggle" data-target-name="form">
+    <i class="fa-regular fa-circle-xmark"></i>
+  </button>
     <% if (@ingredients) %>
     <%= render partial: "ingredients/form"%>
     <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,7 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.hosts << "3c84-223-135-200-101.ngrok-free.app"
   config.action_mailer.default_url_options = { host: "http://localhost:3000" }
   # Settings specified here will take precedence over those in config/application.rb.
 


### PR DESCRIPTION
I added the close button to the form. The button appears only when the form is called from the navbar add button.
Also, I set the default color for the button CSS. This change affects all the buttons, but all buttons look fine on iPhone now.