### PR TITLE
Collapsible Lists

### DIFF
--- a/app/assets/stylesheets/components/_categories.scss
+++ b/app/assets/stylesheets/components/_categories.scss
@@ -3,4 +3,4 @@
   align-items: center;
   gap: 12px;
   justify-content: center;
-};
+}

--- a/app/javascript/controllers/rotate_controller.js
+++ b/app/javascript/controllers/rotate_controller.js
@@ -1,0 +1,48 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="rotate"
+export default class extends Controller {
+  static targets = ["arrow", "list"];
+
+  connect() {
+    console.log("Rotate controller connected");
+
+    // Sets initial state of list to closed
+    this.listTargets.forEach((list) => {
+      list.style.maxHeight = "0px";
+      list.style.overflow = "hidden";
+      list.style.transition = "max-height 0.5s ease";
+    });
+  }
+
+  fire() {
+    console.log("Firing");
+    this.rotate_arrow();
+    this.toggle_list()
+  }
+
+  rotate_arrow() {
+    const arrow = this.arrowTarget;
+    // Checks if arrow has been rotated yet or not
+    const isRotated = arrow.style.transform === "rotate(90deg)";
+    // Sets rotation speed
+    arrow.style.transition = "transform 0.5s ease";
+    // conditionally rotates
+    if (isRotated) {
+      arrow.style.transform = "rotate(0deg)";
+    } else {
+      arrow.style.transform = "rotate(90deg)";
+    }
+  }
+
+  toggle_list() {
+    console.log("Toggling list");
+    const list = this.listTarget
+
+    if (list.style.maxHeight && list.style.maxHeight !== "0px") {
+      list.style.maxHeight = "0px"
+    } else {
+      list.style.maxHeight = list.scrollHeight + "px"
+    }
+  }
+}

--- a/app/views/ingredients/_category.html.erb
+++ b/app/views/ingredients/_category.html.erb
@@ -1,15 +1,16 @@
 
-<div>
+<div class="category-card" data-controller="rotate">
   <%# Select ingredients from user's pantry's ingredients with the correct category %>
+  <%# No need to check if present, already done in the index %>
   <% filtered_ingredients = ingredients.select { |ingredient| ingredient.category_id == category.id } %>
-  <%# Hiding category if it contains nothing %>
-  <%# <% if filtered_ingredients.any? %>
-    <div class="category-title">
-      <i class="<%=category.icon%>"></i>
-      <h3> <%= category.name %> </h3>
-    </div>
+  <div class="category-title">
+    <i class="<%=category.icon%>"></i>
+    <h3> <%= category.name %> </h3>
+    <i data-action="click->rotate#fire" data-rotate-target="arrow" class="fa-solid fa-chevron-right"></i>
+  </div>
+  <div data-rotate-target="list">
     <% filtered_ingredients.each do |ingredient| %>
       <%= render partial: "ingredients_card", locals: { ingredient: ingredient } %>
     <% end %>
-  <%# <% end %>
+  </div>
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,18 +10,18 @@
 
 # Seed the database with the categories
 categories = [
-  { name: "Fruits", icon: "fa-solid fa-lemon" },
-  { name: "Vegetables", icon: "fa-solid fa-carrot" },
-  { name: "Meat", icon: "fa-solid fa-drumstick-bite" },
-  { name: "Fish", icon: "fa-solid fa-fish" },
-  { name: "Dairy", icon: "fa-solid fa-cow" },
-  { name: "Condiments", icon: "fa-solid fa-jar" },
-  { name: "Beverages", icon: "fa-solid fa-coffee" },
-  { name: "Leftovers", icon: "fa-solid fa-utensils" },
-  { name: "Oils", icon: "fa-solid fa-bottle-droplet" },
-  { name: "Spices", icon: "fa-solid fa-pepper-hot" },
-  { name: "Canned", icon: "fa-solid fa-box" },
-  { name: "Miscellaneous", icon: "fa-solid fa-question" }
+  { name: "Fruits", icon: "fa-solid fa-lemon fa-xl" },
+  { name: "Vegetables", icon: "fa-solid fa-carrot fa-xl" },
+  { name: "Meat", icon: "fa-solid fa-drumstick-bite fa-xl" },
+  { name: "Fish", icon: "fa-solid fa-fish fa-xl" },
+  { name: "Dairy", icon: "fa-solid fa-cow fa-xl" },
+  { name: "Condiments", icon: "fa-solid fa-jar fa-xl" },
+  { name: "Beverages", icon: "fa-solid fa-coffee fa-xl" },
+  { name: "Leftovers", icon: "fa-solid fa-utensils fa-xl" },
+  { name: "Oils", icon: "fa-solid fa-bottle-droplet fa-xl" },
+  { name: "Spices", icon: "fa-solid fa-pepper-hot fa-xl" },
+  { name: "Canned", icon: "fa-solid fa-box fa-xl" },
+  { name: "Miscellaneous", icon: "fa-solid fa-question fa-lx" }
 ]
 
 # This will method will either create a category or update an existing one with the icon in the categories array


### PR DESCRIPTION
What I did:

1. Increased the size of the icons on the categories (You need to run db:seed again. Do NOT drop the database, the seedfile is designed to update icons by finding the name).
2. Added a Font-Awesome chevron arrow as the clickable element to collapse the ingredient list. The standard one was too skinny.
3. Implemented a javascript controller to rotate the chevron arrow and expand / contract the list with visible transitions to enhance user experience

Concern 
1. The lists start as hidden. We can start with the list shown if we want, but I'd need to rewrite a few bits in the javascript.
2. If the icons are not big enough, we can add one more size using FA class methods.