### PR TITLE
Fixing name overlap

### DIFF
--- a/app/assets/stylesheets/components/_categories.scss
+++ b/app/assets/stylesheets/components/_categories.scss
@@ -3,4 +3,4 @@
   align-items: center;
   gap: 12px;
   justify-content: center;
-};
+}

--- a/app/assets/stylesheets/components/_pantry_card.scss
+++ b/app/assets/stylesheets/components/_pantry_card.scss
@@ -12,7 +12,10 @@
 
 .card-title{
   margin:0px;
-  font-size: 24px;
+  font-size: 20px;
+  overflow: visible;
+  white-space: normal;
+  max-width: calc(100% - 150px);
 }
 
 .card-content{
@@ -26,7 +29,7 @@
 
 .edit-icon{
   position: absolute;
-  right: 5px;
+  right: 4px;
   top: 50%;
   transform: translateY(-50%);
   background: none;
@@ -35,7 +38,7 @@
 
 .card-date{
   position: absolute;
-  right: 56px;
+  right: 40px;
   top: 50%;
   transform: translateY(-50%);
 }

--- a/app/javascript/controllers/rotate_controller.js
+++ b/app/javascript/controllers/rotate_controller.js
@@ -1,0 +1,48 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="rotate"
+export default class extends Controller {
+  static targets = ["arrow", "list"];
+
+  connect() {
+    console.log("Rotate controller connected");
+
+    // Sets initial state of list to closed
+    this.listTargets.forEach((list) => {
+      list.style.maxHeight = "0px";
+      list.style.overflow = "hidden";
+      list.style.transition = "max-height 0.5s ease";
+    });
+  }
+
+  fire() {
+    console.log("Firing");
+    this.rotate_arrow();
+    this.toggle_list()
+  }
+
+  rotate_arrow() {
+    const arrow = this.arrowTarget;
+    // Checks if arrow has been rotated yet or not
+    const isRotated = arrow.style.transform === "rotate(90deg)";
+    // Sets rotation speed
+    arrow.style.transition = "transform 0.5s ease";
+    // conditionally rotates
+    if (isRotated) {
+      arrow.style.transform = "rotate(0deg)";
+    } else {
+      arrow.style.transform = "rotate(90deg)";
+    }
+  }
+
+  toggle_list() {
+    console.log("Toggling list");
+    const list = this.listTarget
+
+    if (list.style.maxHeight && list.style.maxHeight !== "0px") {
+      list.style.maxHeight = "0px"
+    } else {
+      list.style.maxHeight = list.scrollHeight + "px"
+    }
+  }
+}

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -2,7 +2,7 @@ class Ingredient < ApplicationRecord
   belongs_to :pantry
   belongs_to :category
   has_many :recipe_ingredients
-  validates :name, presence: true
+  validates :name, presence: true, length: { minimum: 2, maximum: 50 }
   validates :category_id, presence: true
   validates :amount, presence: true
   validates :in_pantry, presence: true

--- a/app/views/ingredients/_category.html.erb
+++ b/app/views/ingredients/_category.html.erb
@@ -1,15 +1,16 @@
 
-<div>
+<div class="category-card" data-controller="rotate">
   <%# Select ingredients from user's pantry's ingredients with the correct category %>
+  <%# No need to check if present, already done in the index %>
   <% filtered_ingredients = ingredients.select { |ingredient| ingredient.category_id == category.id } %>
-  <%# Hiding category if it contains nothing %>
-  <%# <% if filtered_ingredients.any? %>
-    <div class="category-title">
-      <i class="<%=category.icon%>"></i>
-      <h3> <%= category.name %> </h3>
-    </div>
+  <div class="category-title">
+    <i class="<%=category.icon%>"></i>
+    <h3> <%= category.name %> </h3>
+    <i data-action="click->rotate#fire" data-rotate-target="arrow" class="fa-solid fa-chevron-right"></i>
+  </div>
+  <div data-rotate-target="list">
     <% filtered_ingredients.each do |ingredient| %>
       <%= render partial: "ingredients_card", locals: { ingredient: ingredient } %>
     <% end %>
-  <%# <% end %>
+  </div>
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,18 +10,18 @@
 
 # Seed the database with the categories
 categories = [
-  { name: "Fruits", icon: "fa-solid fa-lemon" },
-  { name: "Vegetables", icon: "fa-solid fa-carrot" },
-  { name: "Meat", icon: "fa-solid fa-drumstick-bite" },
-  { name: "Fish", icon: "fa-solid fa-fish" },
-  { name: "Dairy", icon: "fa-solid fa-cow" },
-  { name: "Condiments", icon: "fa-solid fa-jar" },
-  { name: "Beverages", icon: "fa-solid fa-coffee" },
-  { name: "Leftovers", icon: "fa-solid fa-utensils" },
-  { name: "Oils", icon: "fa-solid fa-bottle-droplet" },
-  { name: "Spices", icon: "fa-solid fa-pepper-hot" },
-  { name: "Canned", icon: "fa-solid fa-box" },
-  { name: "Miscellaneous", icon: "fa-solid fa-question" }
+  { name: "Fruits", icon: "fa-solid fa-lemon fa-xl" },
+  { name: "Vegetables", icon: "fa-solid fa-carrot fa-xl" },
+  { name: "Meat", icon: "fa-solid fa-drumstick-bite fa-xl" },
+  { name: "Fish", icon: "fa-solid fa-fish fa-xl" },
+  { name: "Dairy", icon: "fa-solid fa-cow fa-xl" },
+  { name: "Condiments", icon: "fa-solid fa-jar fa-xl" },
+  { name: "Beverages", icon: "fa-solid fa-coffee fa-xl" },
+  { name: "Leftovers", icon: "fa-solid fa-utensils fa-xl" },
+  { name: "Oils", icon: "fa-solid fa-bottle-droplet fa-xl" },
+  { name: "Spices", icon: "fa-solid fa-pepper-hot fa-xl" },
+  { name: "Canned", icon: "fa-solid fa-box fa-xl" },
+  { name: "Miscellaneous", icon: "fa-solid fa-question fa-lx" }
 ]
 
 # This will method will either create a category or update an existing one with the icon in the categories array


### PR DESCRIPTION
My system had a cashing issue I had to resolve to see additional CSS changes.
So on my local, I had to rails assets:clobber

I also had to turn off caching on the localhost. 

I post that in case you all start running into the same issue.

What I've done:

1. Adjusted the spacing surrounding the date & edit icons
2. Given the ingredient card title a maximum width of 100% of the screen minus 150px. This makes it dynamic depending on the size of the screen. So if it is a large screen, it displays the ingredient name across one line. If it is a small screen, a long name will overflow down onto the next line (overflow: visible & white-space: normal in the SCSS).
3. Added a validation to the ingredient model to put a maximum length of 50 characters on the ingredient name. This is to prevent the ingredient cards from becoming unattractively tall with excessively long names.