### PR TITLE
Fixed the forms on pantry.

### DIFF
--- a/app/javascript/controllers/rotate_controller.js
+++ b/app/javascript/controllers/rotate_controller.js
@@ -42,7 +42,8 @@ export default class extends Controller {
     if (list.style.maxHeight && list.style.maxHeight !== "0px") {
       list.style.maxHeight = "0px"
     } else {
-      list.style.maxHeight = list.scrollHeight + "px"
+      list.style.maxHeight = (list.scrollHeight + 512) + "px"
+      //list.style.maxHeight = list.scrollHeight + "px"
     }
   }
 }

--- a/app/views/ingredients/_form.html.erb
+++ b/app/views/ingredients/_form.html.erb
@@ -2,26 +2,28 @@
 <% form_ingredient = local_assigns[:ingredient] || @ingredient %>
 
 <div class="styled-form">
-  <%= simple_form_for form_ingredient do |f| %>
+  <%= simple_form_for form_ingredient, html: { id: 'ingredient-form', novalidate: false } do |f| %>
     <div class="form-row">
-      <%= f.input :name, label: "Name", wrapper_html: { class: "form-group" } %>
+      <%= f.input :name, label: "Name", wrapper_html: { class: "form-group" }, required: true %>
     </div>
     <div class="form-row">
-      <%= f.input :amount, label: "Qty", wrapper_html: { class: "form-group" } %>
-      <%= f.input :unit, label: "Unit", wrapper_html: { class: "form-group" } %>
+      <%= f.input :amount, label: "Qty", wrapper_html: { class: "form-group" }, required: true %>
+      <%= f.input :unit, label: "Unit", wrapper_html: { class: "form-group" }, required: true %>
     </div>
     <div class="form-row">
       <%= f.input :category_id, as: :select,
                   collection: Category.all.pluck(:name, :id),
                   prompt: "Select a category",
-                  wrapper_html: { class: "form-group" } %>
+                  wrapper_html: { class: "form-group" },
+                  required: true %>
     </div>
     <div class="form-row">
       <%= f.input :expiration_date,
                   as: :string,
                   input_html: { data: { controller: "datepicker" } },
                   label: "Best by",
-                  wrapper_html: { class: "form-group "} %>
+                  wrapper_html: { class: "form-group" },
+                  required: true %>
       <%= f.submit "Save", class: "pink-button" %>
     </div>
   <% end %>


### PR DESCRIPTION
The "stock manually" form will no longer disappear if there are validation issues. This was done by simply using HTML form validations to prevent the  save button from being clickable (as this would activate the Stimulus toggle regardless of validation) unless everything is valid. 

And the edit form in the pantry will now display fully. The stimulus controller was interfering with the height of the element, so I added more height.