### PR TITLE
Changed collapsable list default state 

### DIFF
--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!"
-  }
-}

--- a/app/javascript/controllers/rotate_controller.js
+++ b/app/javascript/controllers/rotate_controller.js
@@ -7,18 +7,23 @@ export default class extends Controller {
   connect() {
     console.log("Rotate controller connected");
 
-    // Sets initial state of list to closed
+    // Sets initial state of list to open
     this.listTargets.forEach((list) => {
-      list.style.maxHeight = "0px";
+      list.style.maxHeight = (list.scrollHeight + 512) + "px"; // Set to full height
       list.style.overflow = "hidden";
       list.style.transition = "max-height 0.5s ease";
     });
+
+    // Optionally, set the arrow rotation to 90 degrees if you want it to start rotated
+    const arrow = this.arrowTarget;
+    arrow.style.transform = "rotate(90deg)";
+    arrow.style.transition = "transform 0.5s ease";
   }
 
   fire() {
     console.log("Firing");
     this.rotate_arrow();
-    this.toggle_list()
+    this.toggle_list();
   }
 
   rotate_arrow() {
@@ -27,7 +32,7 @@ export default class extends Controller {
     const isRotated = arrow.style.transform === "rotate(90deg)";
     // Sets rotation speed
     arrow.style.transition = "transform 0.5s ease";
-    // conditionally rotates
+    // Conditionally rotates
     if (isRotated) {
       arrow.style.transform = "rotate(0deg)";
     } else {
@@ -37,13 +42,13 @@ export default class extends Controller {
 
   toggle_list() {
     console.log("Toggling list");
-    const list = this.listTarget
+    const list = this.listTarget;
 
     if (list.style.maxHeight && list.style.maxHeight !== "0px") {
-      list.style.maxHeight = "0px"
+      list.style.maxHeight = "0px";
     } else {
-      list.style.maxHeight = (list.scrollHeight + 512) + "px"
-      //list.style.maxHeight = list.scrollHeight + "px"
+      list.style.maxHeight = (list.scrollHeight + 512) + "px";
+      // list.style.maxHeight = list.scrollHeight + "px"
     }
   }
 }


### PR DESCRIPTION
Changed the default state of the pantry categories to not be collapsed. They'll start fully extended. 