### PR TITLE
Refining ingredient card

### DIFF
--- a/app/assets/stylesheets/components/_expiring.scss
+++ b/app/assets/stylesheets/components/_expiring.scss
@@ -11,7 +11,7 @@
   border-radius: 16px;
   box-shadow: 0px 4px 12px 2px rgba(0,0,0,0.2);
   background-color: $ft-pink;
-  height: 34px;
+  height: 36px;
 }
 
 .alert-icon {
@@ -20,10 +20,12 @@
 .expiring-message {
   padding: 4px;
   font-size: 16px;
-  margin-left: -22px;
+  margin-left: -28px;
   font-weight: bold;
   color: white;
   z-index: 2;
+  overflow: visible;
+  white-space: normal;
 }
 
 @keyframes pulseRotate {

--- a/app/assets/stylesheets/components/_pantry_card.scss
+++ b/app/assets/stylesheets/components/_pantry_card.scss
@@ -5,7 +5,7 @@
   background-color: white;
 }
 
-.card {
+.ingredient-card {
   padding: 5px 12px;
   background-color: white;
   border: none;
@@ -13,84 +13,9 @@
   border-radius: 16px;
   position: relative;
   box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, 0.1);
-//   // flex-direction: row;
-}
-
-.card-title {
-  margin: 0px;
-  font-size: 20px;
-  font-weight: bold;
-  overflow: visible;
-  white-space: normal;
-  // max-width: calc(100% - 150px);
-}
-
-.card-content {
-  // margin: 0px;
-//   display: flex;
-  font-size: 20px;
-//   // flex-direction: column;
-text-align: center;
-align-items: center;
-}
-
-.card-detail {
-//   margin-right: 20px;
-display: flex;
-// text-align: center;
-align-items: center;
-justify-content: center;
-}
-
-#amount {
-  margin-right: 5px;
-}
-
-// .edit-icon {
-//   position: absolute;
-//   right: 45px;
-//   top: 50%;
-//   transform: translateY(-50%);
-//   background: none;
-//   border: none;
-// }
-
-.delete-icon {
-  position: absolute;
-  right: 4px;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  border: 0px;
-  border-top: 0px;
-  border-bottom: 0px;
-  border-left: 0px;
-  border-right: 0px;
-  background-color: white;
-  font-size: 32px;
-  color: grey;
-}
-
-// .card-date {
-//   position: absolute;
-//   right: 60px;
-//   top: 50%;
-//   transform: translateY(-50%);
-// }
-
-.expiring-notice {
-  background: gray;
-  border-radius: 8px;
-  padding: 4px;
-  color: white;
-}
-
-.expired-notice {
-  background: $ft-pink;
-  border-radius: 8px;
-  padding: 4px;
-  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .card-picture-box {
@@ -104,7 +29,62 @@ justify-content: center;
 .card-image {
   height: 100%;
   width: 100%;
+}
 
+.card-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.card-title {
+  margin: 0px;
+  font-size: 20px;
+  font-weight: bold;
+  overflow: visible;
+  white-space: normal;
+  // max-width: calc(100% - 150px);
+}
+
+.amount-and-unit {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#amount {
+  margin-right: 5px;
+}
+
+.delete-icon {
+  // position: absolute;
+  // right: 4px;
+  // top: 50%;
+  // transform: translateY(-50%);
+  background: none;
+  border: none;
+  border: 0px;
+  border-top: 0px;
+  border-bottom: 0px;
+  border-left: 0px;
+  border-right: 0px;
+  background-color: white;
+  font-size: 32px;
+  color: grey;
+}
+
+.expiring-notice {
+  background: gray;
+  border-radius: 8px;
+  padding: 4px;
+  color: white;
+}
+
+.expired-notice {
+  background: $ft-pink;
+  border-radius: 8px;
+  padding: 4px;
+  color: white;
 }
 
 .edit-field {

--- a/app/assets/stylesheets/components/_pantry_card.scss
+++ b/app/assets/stylesheets/components/_pantry_card.scss
@@ -35,6 +35,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-left: -40px;
+  width: 50%;
 }
 
 .card-title {
@@ -43,7 +45,8 @@
   font-weight: bold;
   overflow: visible;
   white-space: normal;
-  // max-width: calc(100% - 150px);
+  word-wrap: break-word;
+  text-align: center;
 }
 
 .amount-and-unit {

--- a/app/assets/stylesheets/components/_pantry_card.scss
+++ b/app/assets/stylesheets/components/_pantry_card.scss
@@ -50,27 +50,38 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 4px;
 }
 
-#amount {
-  margin-right: 5px;
+.ingredient-card-icons {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+}
+
+.ingredient-card-icons button {
+  border: none;
+  background: none;
+  padding: 0;
+}
+
+.expire-icon, .delete-icon {
+  display: block;
+  text-align: center;
+}
+
+.expire-icon {
+  color: $ft-pink;
+  font-size: 1.5em;
 }
 
 .delete-icon {
-  // position: absolute;
-  // right: 4px;
-  // top: 50%;
-  // transform: translateY(-50%);
-  background: none;
-  border: none;
-  border: 0px;
-  border-top: 0px;
-  border-bottom: 0px;
-  border-left: 0px;
-  border-right: 0px;
-  background-color: white;
-  font-size: 32px;
   color: grey;
+}
+
+.delete-icon:hover {
+  color: black;
 }
 
 .expiring-notice {

--- a/app/assets/stylesheets/components/_pantry_card.scss
+++ b/app/assets/stylesheets/components/_pantry_card.scss
@@ -60,7 +60,7 @@
 .ingredient-card-icons {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
   align-items: center;
 }
 

--- a/app/assets/stylesheets/components/_pantry_card.scss
+++ b/app/assets/stylesheets/components/_pantry_card.scss
@@ -54,6 +54,7 @@
   align-items: center;
   justify-content: center;
   gap: 4px;
+  text-align: center;
 }
 
 .ingredient-card-icons {
@@ -112,4 +113,16 @@
   box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.5); /* Adjust color and size as needed */
   transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
   border: var(--bs-border-width) solid var(--bs-border-color);
+  text-align: center;
+}
+
+.error-messages {
+  display: none;
+  color: white;
+  font-size: 16px;
+  background: $ft-pink;
+  padding: 4px;
+  border-radius: 16px;
+  text-align: center;
+  box-shadow: 0px 4px 12px 2px rgba(0,0,0,0.2);
 }

--- a/app/assets/stylesheets/components/_search.scss
+++ b/app/assets/stylesheets/components/_search.scss
@@ -8,9 +8,9 @@
 
 .search-bar {
   margin-right: 16px;
-  height: 34px;
   position: relative;
   display: flex;
+  height: 36px;
 }
 
 .search-bar input {

--- a/app/assets/stylesheets/components/_search.scss
+++ b/app/assets/stylesheets/components/_search.scss
@@ -21,6 +21,7 @@
   font-size: 16px;
   text-align: center;
   height: auto;
+  box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, 0.1);
 }
 
 .search-icon {

--- a/app/javascript/controllers/edit_controller.js
+++ b/app/javascript/controllers/edit_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="edit"
 export default class extends Controller {
-  static targets = ["nameContent", "nameInput", "amountContent", "amountInput", "unitContent", "unitInput", "expirationContent", "expirationInput"]
+  static targets = ["nameContent", "nameInput", "amountContent", "amountInput", "unitContent", "unitInput", "expirationContent", "expirationInput", "errorMessages"]
 
   connect() {
     console.log("Edit connected");
@@ -110,19 +110,19 @@ export default class extends Controller {
     // Sends the new value to the DB
     return this.save(field, newValue)
       .then(response => {
-        console.log("Response:", response);
+        console.log("Response:", response,);
         if (response.status === "success") {
           contentTarget.textContent = response.ingredient[field];
           inputTarget.classList.add("d-none");
           contentTarget.classList.remove("d-none");
-          this.clearErrorMessages();
+          this.clearErrorMessages(inputTarget);
         } else {
-          this.showErrorMessages(response.errors);
+          this.showErrorMessages(response.errors, inputTarget);
         }
       })
       .catch(error => {
         console.error("Error:", error);
-        this.showErrorMessages(["An error occurred. Please try again."]);
+        this.showErrorMessages(["An error occurred. Please try again."], inputTarget);
       });
   }
 
@@ -148,15 +148,18 @@ export default class extends Controller {
     });
   }
 
-  showErrorMessages(errors) {
-    const errorContainer = document.getElementById('error-messages');
-    errorContainer.style.display = 'block';
-    errorContainer.innerHTML = errors.join('<br>');
+  showErrorMessages(errors, inputTarget) {
+    this.errorMessagesTarget.style.display = 'block';
+    this.errorMessagesTarget.innerHTML = errors.map(error => `<div>${error}</div>`).join('');
+    inputTarget.style.border = '1px solid red';
+    inputTarget.style.boxShadow = '0 0 0 0.2rem rgba(255, 0, 0, 0.25)';
   }
 
-  clearErrorMessages() {
-    const errorContainer = document.getElementById('error-messages');
-    errorContainer.style.display = 'none';
-    errorContainer.innerHTML = '';
+  clearErrorMessages(inputTarget) {
+    console.log("clearing:", inputTarget);
+    this.errorMessagesTarget.style.display = 'none';
+    this.errorMessagesTarget.innerHTML = '';
+    inputTarget.style.border = 'none';
+    inputTarget.style.boxShadow = '0 0 0 3px rgba(0, 123, 255, 0.5)';
   }
 }

--- a/app/javascript/controllers/edit_controller.js
+++ b/app/javascript/controllers/edit_controller.js
@@ -35,28 +35,48 @@ export default class extends Controller {
     inputTarget.focus();
 
     if (field === "expiration_date") {
-      const fp = flatpickr(inputTarget, {
+
+      let fp;
+
+      fp = flatpickr(inputTarget, {
         onClose: () => {
           console.log("Flatpickr closed for", inputTarget);
+          document.removeEventListener('mousedown', this.handleClickOutside);
           this.update(contentTarget, inputTarget, field);
           fp.destroy();
         },
         onChange: () => {
           console.log("Date changed for", inputTarget);
+          document.removeEventListener('mousedown', this.handleClickOutside);
           this.update(contentTarget, inputTarget, field);
           fp.destroy();
-        }
-      });
-
-      // Prevents backspace from cleadring the entire input
-      inputTarget.addEventListener("keydown", (event) => {
-        if (event.key === "Backspace" && inputTarget.value.length === 0) {
-          event.preventDefault();
-          fp.destroy();
-          this.toggleEditing(contentTarget, inputTarget, field);
-        }
-      });
-
+        },
+        onReady: () => {
+          setTimeout(() => {
+            this.handleClickOutside = (event) => {
+              const calendar = document.querySelector('.flatpickr-calendar');
+              console.log("Calendar:", calendar);
+              if (!inputTarget.contains(event.target) && !calendar.contains(event.target)) {
+                console.log("Clicked outside input field");
+                document.removeEventListener('mousedown', this.handleClickOutside);
+                fp.close();
+                this.update(contentTarget, inputTarget, field);
+                fp.destroy();
+              }
+            };
+            document.addEventListener('mousedown', this.handleClickOutside);
+          }, 500);
+      },
+      positionElement: inputTarget
+    });
+      // Prevents backspace from clearing the entire input
+    inputTarget.addEventListener("keydown", (event) => {
+      if (event.key === "Backspace" && inputTarget.value.length === 0) {
+        event.preventDefault();
+        fp.destroy();
+        this.toggleEditing(contentTarget, inputTarget, field);
+      }
+    });
     } else {
       this.moveCursorToEnd(inputTarget);
       inputTarget.addEventListener("blur", () => {

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -7,7 +7,6 @@ class Ingredient < ApplicationRecord
   validates :amount, presence: true
   validates :expiration_date, presence: true
   validates :in_pantry, presence: true
-  # validates :expiration_date, presence: true
   enum status: { in_pantry: 0, in_cart: 1 }
   before_save :update_image_url, if: :name_changed?
 

--- a/app/views/ingredients/_category.html.erb
+++ b/app/views/ingredients/_category.html.erb
@@ -2,7 +2,7 @@
 <div class="category-card" data-controller="rotate">
   <%# Select ingredients from user's pantry's ingredients with the correct category %>
   <%# No need to check if present, already done in the index %>
-  <% filtered_ingredients = ingredients.select { |ingredient| ingredient.category_id == category.id } %>
+  <% filtered_ingredients = ingredients.select { |ingredient| ingredient.category_id == category.id }.sort_by { |ingredient| ingredient.expiration_date }.reverse %>
   <div class="category-title">
     <i class="<%=category.icon%>"></i>
     <h3> <%= category.name %> </h3>

--- a/app/views/ingredients/_category.html.erb
+++ b/app/views/ingredients/_category.html.erb
@@ -1,6 +1,6 @@
 
 <div class="category-card" data-controller="rotate">
-  <%# Select ingredients from user's pantry's ingredients with the correct category %>
+  <%# Select ingredients from user's pantry's ingredients with the correct category, and then sorts by expiration %>
   <%# No need to check if present, already done in the index %>
   <% filtered_ingredients = ingredients.select { |ingredient| ingredient.category_id == category.id }.sort_by { |ingredient| ingredient.expiration_date }.reverse %>
   <div class="category-title">

--- a/app/views/ingredients/_ingredients_card.html.erb
+++ b/app/views/ingredients/_ingredients_card.html.erb
@@ -1,5 +1,4 @@
 <div class="ingredient-card" data-controller="toggler edit" data-url="<%= ingredient_path(ingredient) %>">
-
   <%# just the picture %>
   <div class="card-picture-box">
       <% if ingredient.image_url == "" %>
@@ -9,14 +8,12 @@
       <% end %>
     <%= image_tag ingredient_pic, class: 'card-image' %>
   </div>
-
   <%# has the title amount counter and expiration date %>
   <div class="card-info">
     <div class="card-title"  data-field="name" data-action="click->edit#edit">
       <span  data-edit-target="nameContent"><%= ingredient.name %> </span>
       <input type="text" data-edit-target="nameInput" value="<%= ingredient.name %>" class="edit-field d-none">
     </div>
-
     <div class="amount-and-unit">
     <%# conditional leans up display, returns whole numbers & decimals %>
       <% if ingredient.amount % 1 == 0 %>
@@ -33,7 +30,6 @@
         <input type="text" data-edit-target="unitInput" value="<%= ingredient.unit %>" class="edit-field d-none">
       </div>
     </div>
-
     <% if ingredient.expiration_date %>
       <div class="card-date">
         <span data-edit-target="expirationContent" data-field="expiration_date" data-action="click->edit#edit">

--- a/app/views/ingredients/_ingredients_card.html.erb
+++ b/app/views/ingredients/_ingredients_card.html.erb
@@ -1,27 +1,23 @@
-<div id="ingredient-card" data-controller="toggler edit" data-url="<%= ingredient_path(ingredient) %>">
+<div class="ingredient-card" data-controller="toggler edit" data-url="<%= ingredient_path(ingredient) %>">
 
-  <%# has all the cards content should be able to evenly space them %>
-  <div class="card">
-    <div class="d-flex justify-content-between">
-
-<% # just the picture %>
-    <div class="card-picture-box">
+  <%# just the picture %>
+  <div class="card-picture-box">
       <% if ingredient.image_url == "" %>
         <% ingredient_pic = "meal-food-icon.png" %>
       <% else %>
         <% ingredient_pic = ingredient.image_url %>
       <% end %>
-      <%= image_tag ingredient_pic, class: 'card-image' %></div>
+    <%= image_tag ingredient_pic, class: 'card-image' %>
+  </div>
 
-<% # has the title amount counter and expiration date %>
-    <div class="card-content">
+  <%# has the title amount counter and expiration date %>
+  <div class="card-info">
+    <div class="card-title"  data-field="name" data-action="click->edit#edit">
+      <span  data-edit-target="nameContent"><%= ingredient.name %> </span>
+      <input type="text" data-edit-target="nameInput" value="<%= ingredient.name %>" class="edit-field d-none">
+    </div>
 
-      <div class="card-title"  data-field="name" data-action="click->edit#edit">
-        <span  data-edit-target="nameContent"><%= ingredient.name %> </span>
-        <input type="text" data-edit-target="nameInput" value="<%= ingredient.name %>" class="edit-field d-none">
-      </div>
-
-      <div class="card-detail amount-and-unit">
+      <div class="amount-and-unit">
       <%# conditional leans up display, returns whole numbers & decimals %>
         <% if ingredient.amount % 1 == 0 %>
           <% amount = ingredient.amount.to_i %>
@@ -39,37 +35,33 @@
         <div id="error-messages" class="error-messages" style="display: none; color: red;"></div>
       </div>
 
-        <% if ingredient.expiration_date %>
-          <div class="card-date">
-            <%# Sets variable for days to / since expiration, makes code dry %>
-              <% expires = (ingredient.expiration_date - Date.today).to_i %>
-            <%# Accounts for singular day %>
-            <% day_word = expires.abs == 1 ? "day" : "days" %>
-            <span data-edit-target="expirationContent" data-field="expiration_date" data-action="click->edit#edit">
-              <% if expires.positive? && expires <= 7 %>
-                <div class="expiring-notice">
-                  <span> Expires in <%= expires %> <%= day_word %> </span>
-                </div>
-              <% elsif expires.negative? %>
-                <div class="expired-notice">
-                  <span> Expired <%= expires.abs %> <%= day_word %> ago! </span>
-                </div>
-              <% else %>
-                <%= ingredient.expiration_date %>
-              <% end %>
-            </span>
-            <input type="text" data-controller="datepicker" data-datepicker-target="expirationInput" data-edit-target="expirationInput" class="d-none" value="<%= ingredient.expiration_date %>">
-            <div id="error-messages" class="error-messages" style="display: none; color: red;"></div>
-          </div>
-        <% end %>
-
-    </div>
-
-<% # just the trash icon %>
-      <%= button_to ingredient_path(ingredient), {method: :delete, data: { confirm: 'Are you sure?' }, class: 'delete-icon fa-solid fa-trash-can'} do %>
+      <% if ingredient.expiration_date %>
+        <div class="card-date">
+          <%# Sets variable for days to / since expiration, makes code dry %>
+            <% expires = (ingredient.expiration_date - Date.today).to_i %>
+          <%# Accounts for singular day %>
+          <% day_word = expires.abs == 1 ? "day" : "days" %>
+          <span data-edit-target="expirationContent" data-field="expiration_date" data-action="click->edit#edit">
+            <% if expires.positive? && expires <= 7 %>
+              <div class="expiring-notice">
+                <span> Expires in <%= expires %> <%= day_word %> </span>
+              </div>
+            <% elsif expires.negative? %>
+              <div class="expired-notice">
+                <span> Expired <%= expires.abs %> <%= day_word %> ago! </span>
+              </div>
+            <% else %>
+              <%= ingredient.expiration_date %>
+            <% end %>
+          </span>
+          <input type="text" data-controller="datepicker" data-datepicker-target="expirationInput" data-edit-target="expirationInput" class="d-none" value="<%= ingredient.expiration_date %>">
+          <div id="error-messages" class="error-messages" style="display: none; color: red;"></div>
+        </div>
       <% end %>
-
-    </div>
-
+      <%# just the trash icon %>
+  </div>
+  <div class="ingredient-card-icons">
+    <%= button_to ingredient_path(ingredient), {method: :delete, data: { confirm: 'Are you sure?' }, class: 'delete-icon fa-solid fa-trash-can'} do %>
+    <% end %>
   </div>
 </div>

--- a/app/views/ingredients/_ingredients_card.html.erb
+++ b/app/views/ingredients/_ingredients_card.html.erb
@@ -58,7 +58,7 @@
       <% end %>
     <% else %>
       <%= button_to ingredient_path(ingredient), {method: :delete, data: { confirm: 'Are you sure?' }} do %>
-        <div class="delete-icon fa-solid fa-trash-can" style="font-size: 30px;"></div>
+        <div class="delete-icon fa-solid fa-trash-can" style="font-size: 32px;"></div>
       <% end %>
     <% end %>
   </div>

--- a/app/views/ingredients/_ingredients_card.html.erb
+++ b/app/views/ingredients/_ingredients_card.html.erb
@@ -17,48 +17,33 @@
       <input type="text" data-edit-target="nameInput" value="<%= ingredient.name %>" class="edit-field d-none">
     </div>
 
-      <div class="amount-and-unit">
-      <%# conditional leans up display, returns whole numbers & decimals %>
-        <% if ingredient.amount % 1 == 0 %>
-          <% amount = ingredient.amount.to_i %>
-        <% else %>
-          <% amount = ingredient.amount %>
-        <% end %>
-        <div id="amount" data-action="click->edit#edit" data-field="amount">
-          <span data-edit-target="amountContent"><%= amount %> </span>
-          <input type="number" data-edit-target="amountInput" value="<%= amount %>" class="edit-field d-none">
-        </div>
-        <div id="unit" data-action="click->edit#edit" data-field="unit">
-          <span data-edit-target="unitContent"><%= ingredient.unit %> </span>
-          <input type="text" data-edit-target="unitInput" value="<%= ingredient.unit %>" class="edit-field d-none">
-        </div>
+    <div class="amount-and-unit">
+    <%# conditional leans up display, returns whole numbers & decimals %>
+      <% if ingredient.amount % 1 == 0 %>
+        <% amount = ingredient.amount.to_i %>
+      <% else %>
+        <% amount = ingredient.amount %>
+      <% end %>
+      <div id="amount" data-action="click->edit#edit" data-field="amount">
+        <span data-edit-target="amountContent"><%= amount %> </span>
+        <input type="number" data-edit-target="amountInput" value="<%= amount %>" class="edit-field d-none">
+      </div>
+      <div id="unit" data-action="click->edit#edit" data-field="unit">
+        <span data-edit-target="unitContent"><%= ingredient.unit %> </span>
+        <input type="text" data-edit-target="unitInput" value="<%= ingredient.unit %>" class="edit-field d-none">
+      </div>
+      <div id="error-messages" class="error-messages" style="display: none; color: red;"></div>
+    </div>
+
+    <% if ingredient.expiration_date %>
+      <div class="card-date">
+        <span data-edit-target="expirationContent" data-field="expiration_date" data-action="click->edit#edit">
+          <%= ingredient.expiration_date %>
+        </span>
+        <input type="text" data-controller="datepicker" data-datepicker-target="expirationInput" data-edit-target="expirationInput" class="d-none" value="<%= ingredient.expiration_date %>">
         <div id="error-messages" class="error-messages" style="display: none; color: red;"></div>
       </div>
-
-      <% if ingredient.expiration_date %>
-        <div class="card-date">
-          <%# Sets variable for days to / since expiration, makes code dry %>
-            <% expires = (ingredient.expiration_date - Date.today).to_i %>
-          <%# Accounts for singular day %>
-          <% day_word = expires.abs == 1 ? "day" : "days" %>
-          <span data-edit-target="expirationContent" data-field="expiration_date" data-action="click->edit#edit">
-            <% if expires.positive? && expires <= 7 %>
-              <div class="expiring-notice">
-                <span> Expires in <%= expires %> <%= day_word %> </span>
-              </div>
-            <% elsif expires.negative? %>
-              <div class="expired-notice">
-                <span> Expired <%= expires.abs %> <%= day_word %> ago! </span>
-              </div>
-            <% else %>
-              <%= ingredient.expiration_date %>
-            <% end %>
-          </span>
-          <input type="text" data-controller="datepicker" data-datepicker-target="expirationInput" data-edit-target="expirationInput" class="d-none" value="<%= ingredient.expiration_date %>">
-          <div id="error-messages" class="error-messages" style="display: none; color: red;"></div>
-        </div>
-      <% end %>
-      <%# just the trash icon %>
+    <% end %>
   </div>
   <div class="ingredient-card-icons">
     <% expires = (ingredient.expiration_date - Date.today).to_i %>

--- a/app/views/ingredients/_ingredients_card.html.erb
+++ b/app/views/ingredients/_ingredients_card.html.erb
@@ -61,7 +61,21 @@
       <%# just the trash icon %>
   </div>
   <div class="ingredient-card-icons">
-    <%= button_to ingredient_path(ingredient), {method: :delete, data: { confirm: 'Are you sure?' }, class: 'delete-icon fa-solid fa-trash-can'} do %>
+    <% expires = (ingredient.expiration_date - Date.today).to_i %>
+    <% if expires >= 0 && expires <= 7 %>
+      <div class="expire-icon fa-solid fa-circle-exclamation"></div>
+      <%= button_to ingredient_path(ingredient), {method: :delete, data: { confirm: 'Are you sure?' }} do %>
+        <div class="delete-icon fa-solid fa-trash-can" style="font-size: 1.5em;"></div>
+      <% end %>
+    <% elsif expires.negative? %>
+      <div class="expire-icon fa-solid fa-skull-crossbones"></div>
+      <%= button_to ingredient_path(ingredient), {method: :delete, data: { confirm: 'Are you sure?' }} do %>
+        <div class="delete-icon fa-solid fa-trash-can" style="font-size: 1.5em;"></div>
+      <% end %>
+    <% else %>
+      <%= button_to ingredient_path(ingredient), {method: :delete, data: { confirm: 'Are you sure?' }} do %>
+        <div class="delete-icon fa-solid fa-trash-can" style="font-size: 30px;"></div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/ingredients/_ingredients_card.html.erb
+++ b/app/views/ingredients/_ingredients_card.html.erb
@@ -32,7 +32,6 @@
         <span data-edit-target="unitContent"><%= ingredient.unit %> </span>
         <input type="text" data-edit-target="unitInput" value="<%= ingredient.unit %>" class="edit-field d-none">
       </div>
-      <div id="error-messages" class="error-messages" style="display: none; color: red;"></div>
     </div>
 
     <% if ingredient.expiration_date %>
@@ -41,15 +40,15 @@
           <%= ingredient.expiration_date %>
         </span>
         <input type="text" data-controller="datepicker" data-datepicker-target="expirationInput" data-edit-target="expirationInput" class="d-none edit-field" value="<%= ingredient.expiration_date %>">
-        <div id="error-messages" class="error-messages" style="display: none; color: red;"></div>
       </div>
     <% end %>
+    <div class="error-messages" data-edit-target="errorMessages"></div>
   </div>
   <div class="ingredient-card-icons">
     <% expires = (ingredient.expiration_date - Date.today).to_i %>
     <% if expires >= 0 && expires <= 7 %>
       <div class="expire-icon fa-solid fa-circle-exclamation"></div>
-      <%= button_to ingredient_path(ingredient), {method: :delete, data: { confirm: 'Are you sure?' }} do %>
+      <%= button_to ingredient_path(ingredient), {metshod: :delete, data: { confirm: 'Are you sure?' }} do %>
         <div class="delete-icon fa-solid fa-trash-can" style="font-size: 1.5em;"></div>
       <% end %>
     <% elsif expires.negative? %>

--- a/app/views/ingredients/_ingredients_card.html.erb
+++ b/app/views/ingredients/_ingredients_card.html.erb
@@ -40,7 +40,7 @@
         <span data-edit-target="expirationContent" data-field="expiration_date" data-action="click->edit#edit">
           <%= ingredient.expiration_date %>
         </span>
-        <input type="text" data-controller="datepicker" data-datepicker-target="expirationInput" data-edit-target="expirationInput" class="d-none" value="<%= ingredient.expiration_date %>">
+        <input type="text" data-controller="datepicker" data-datepicker-target="expirationInput" data-edit-target="expirationInput" class="d-none edit-field" value="<%= ingredient.expiration_date %>">
         <div id="error-messages" class="error-messages" style="display: none; color: red;"></div>
       </div>
     <% end %>

--- a/app/views/ingredients/index.html.erb
+++ b/app/views/ingredients/index.html.erb
@@ -10,7 +10,7 @@
             <div class="alert-icon fa-solid fa-circle-exclamation fa-2xl" data-alert-target="icon"></div>
           <div class="expiring-message" data-alert-target="message">
             <%= link_to expiring_ingredients_path, style: "text-decoration: none; color: white;" do %>
-              <%= @expiring.length %> <%= "ingredient".pluralize(@expiring.size) %> expiring soon!
+              <%= @expiring.length %> <%= "item".pluralize(@expiring.size) %> expiring soon!
             <% end %>
           </div>
         <% end %>

--- a/app/views/ingredients/index.html.erb
+++ b/app/views/ingredients/index.html.erb
@@ -10,7 +10,7 @@
             <div class="alert-icon fa-solid fa-circle-exclamation fa-2xl" data-alert-target="icon"></div>
           <div class="expiring-message" data-alert-target="message">
             <%= link_to expiring_ingredients_path, style: "text-decoration: none; color: white;" do %>
-              <%= @expiring.length %> items expiring soon!
+              <%= @expiring.length %> <%= "ingredient".pluralize(@expiring.size) %> expiring soon!
             <% end %>
           </div>
         <% end %>


### PR DESCRIPTION
I did a lot. Only meant to spend an hour and ended up blowing my whole day on it. I'll regret it next week.

Here's what I've done:

1. Fixed expiring alert message to pluralize depending on number of expiring items. (showed plural even with just one)
2. Sorted out alignment issues on the ingredients card by extensive refactoring. I did away with many unnecessary divs and organized the existing card content into clearer sections, rather than absolute positioning.
3. Reorganized CSS classes for the pantry so that they flow from top to bottom, corresponding to what's on the HTML page. Combined / renamed some of the classes to do away with redundancy and increase explicitness.
4. Added the expiration icon to the ingredient card, in a container with the delete button. They dynamically shuffle / resize depending on expiring icon presence or not. 
5. Added a skull and crossbones icon for items that are past their best-by dates. Just for fun.
6. Fixed an issue in the calendar editing where it wasn't saving and returning to content display after clickaway.  There's still a bug where it's funky on mobile that I haven't sorted out yet, but as long as you click a calendar date it still works so it's not a priority. Need to read the documentation as to why the mobile stuff there is so different (I was litterally going crazy for 3ish hours today trying to figure out. I went into a rage trying to fix it and didn't come out until 3. Missed lunch).
7. Fixed the issue of the invalid entry icons appearing on the wrong card.
8. Added styling to those error messages.
9. Added a line in the category card to sort out the ingredients under each category from soonest to expire to furthest
10. Added guards to the CSS to prevent long ingredient names from overlapping with other card features
11. Cleaned up some minor spacing issues.