### PR TITLE
Small tweaks on css and texts

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -80,7 +80,7 @@ align-items: center;
   border: none;
   border-radius: 15px;
   padding: 10px 20px;
-  font-size: 16px;
+  font-size: 20px;
   cursor: pointer;
   outline: none;
   box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);

--- a/app/assets/stylesheets/components/_recipe_card.scss
+++ b/app/assets/stylesheets/components/_recipe_card.scss
@@ -74,15 +74,23 @@
 .recipe-ingredient-card{
   list-style: none;
   padding:5px 12px;
-  background-color: white;
+  background-color: #f4f4f4;
   border: none;
   margin: 8px;
   border-radius: 8px;
   // position: relative;
-  box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.1);
+  // box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.1);
   // flex-basis: 45%;
   flex-grow: 0;
   text-align: left;
+}
+
+.recipe-ingredient-info{
+  padding:5px 12px;
+  background-color: #f4f4f4;
+  border: none;
+  margin: 8px;
+  border-radius: 8px;
 
 }
 
@@ -137,6 +145,11 @@
 }
 .button-edit-recipe > a{
   text-decoration: none;
+}
+
+.link-delete-recipe{
+  padding:8px;
+  font-size: 16px;
 }
 
 .btn_recipe_save {

--- a/app/assets/stylesheets/components/_search.scss
+++ b/app/assets/stylesheets/components/_search.scss
@@ -32,6 +32,10 @@
   pointer-events: none;
 }
 
+.search-container {
+  text-align: center;
+}
+
 .search-bar-recipe {
   margin: 0px 16px;
   position: relative;

--- a/app/views/recipe_searches/result.html.erb
+++ b/app/views/recipe_searches/result.html.erb
@@ -28,9 +28,9 @@
           <%= f.fields_for 'recipe_ingredients_attributes[]', RecipeIngredient.new do |fields| %>
             <% extendedIngredients.each do |ingredient| %>
               <li class="recipe-ingredient-card">
-                <span style="font-weight:bold; margin-right: 8px;"><%= name = ingredient["name"] %></span>
-                <%= amount = ingredient["measures"]["metric"]["amount"] %>
-                <%= unit = ingredient["measures"]["metric"]["unitLong"] %>
+                <span style="font-weight:bold; margin-right: 8px;"><%= name = ingredient["name"].titleize %></span>
+                <%= amount = (ingredient["measures"]["metric"]["amount"] - ingredient["measures"]["metric"]["amount"].to_i) > 0 ? ingredient["measures"]["metric"]["amount"] : ingredient["measures"]["metric"]["amount"].to_i %>
+                <%= unit = ingredient["measures"]["metric"]["unitLong"].titleize %>
                 <% category_name = Category::CATEGORY_MAPPING[ingredient["aisle"]] %>
                 <% categoryid = Category.find_by(name:"#{category_name}").id %>
               </li>
@@ -42,10 +42,12 @@
           <% end %>
       </ul>
       <h2>Descriptions</h2>
+       <div class="recipe-ingredient-info">
         <%= simple_format(summary) %>
+        </div>
     </div>
     <div class="btn_recipe_save">
-      <%= f.submit "Save this recipe", class: "pink-button" %>
+      <%= f.submit "Save this recipe", class: "btn-new-search" %>
     </div>
 <% end %>
 

--- a/app/views/recipe_searches/search.html.erb
+++ b/app/views/recipe_searches/search.html.erb
@@ -1,4 +1,5 @@
 <h1>Search Results</h1>
+<div class="search-container">
   <div class="search-bar-recipe">
         <i class="search-icon fa-solid fa-magnifying-glass"></i>
     <%= form_with url: search_recipes_path, method: :get, class: "d-flex" do %>
@@ -11,26 +12,27 @@
     <% end %>
   </div>
 
-<% if @results %>
-  <ul class="recipes-container">
-    <% @results.each do |value| %>
-      <% title = value["title"] %>
-      <% image = value["image"] %>
-      <% missedCount = value["missedIngredientCount"] %>
-      <% usedCount = value["usedIngredientCount"] %>
-      <% recipeid = value["id"] %>
+  <% if @results %>
+    <ul class="recipes-container">
+      <% @results.each do |value| %>
+        <% title = value["title"] %>
+        <% image = value["image"] %>
+        <% missedCount = value["missedIngredientCount"] %>
+        <% usedCount = value["usedIngredientCount"] %>
+        <% recipeid = value["id"] %>
 
-      <%= link_to result_recipes_path(recipe: recipeid), class: "recipe-card" do%>
-        <li>
-            <%= image_tag image, class:"recipe-card-img", alt: '...' %>
-          <div class="info">
-              <div class="title"><%= title %></div>
-              <div class="subtitle"><%= "#{missedCount}/#{missedCount+usedCount} ingredients missing" %></div>
-          </div>
-        </li>
+        <%= link_to result_recipes_path(recipe: recipeid), class: "recipe-card" do%>
+          <li>
+              <%= image_tag image, class:"recipe-card-img", alt: '...' %>
+            <div class="info">
+                <div class="title"><%= title %></div>
+                <div class="subtitle"><%= "#{missedCount}/#{missedCount+usedCount} ingredients missing" %></div>
+            </div>
+          </li>
+        <% end %>
       <% end %>
-    <% end %>
-  </ul>
-<% else %>
-No recipe found!
-<% end %>
+    </ul>
+  <% else %>
+  No recipe found!
+  <% end %>
+</div>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -14,15 +14,15 @@
   <div class="recipe-detail">
     <div class="btn-recipe-shoppinglist">
       <h2>Ingredients</h2>
-      <span class="button-edit-recipe"><%= button_to "Create Shopping List", to_ingredients_recipe_recipe_ingredients_path(@recipe), method: :post, class: "btn-new-search" %></span>
+      <span class="button-edit-recipe"><%= button_to "Add to Shopping List", to_ingredients_recipe_recipe_ingredients_path(@recipe), method: :post, class: "btn-new-search" %></span>
     </div>
     <ul class="recipe-ingredient">
       <% if @recipe_ingredients.present? %>
         <% @recipe_ingredients.each do |recipe_ingredient| %>
           <li class="recipe-ingredient-card">
-            <%= recipe_ingredient.name %>
-            <%= recipe_ingredient.amount %>
-            <%= recipe_ingredient.unit %>
+            <span style="font-weight:bold; margin-right: 8px;"><%= recipe_ingredient.name.titleize %></span>
+            <%= (recipe_ingredient.amount - recipe_ingredient.amount.to_i) > 0 ? recipe_ingredient.amount : recipe_ingredient.amount.to_i %>
+            <%= recipe_ingredient.unit.titleize %>
             <%= link_to edit_recipe_recipe_ingredient_path(@recipe, recipe_ingredient), class: "icon-recipe-edit" do %>
               <i class="fa-solid fa-pen"></i>
             <% end %>
@@ -36,11 +36,13 @@
     <% end %>
     </ul>
     <h2>Descriptions</h2>
+    <div class="recipe-ingredient-info">
       <%= simple_format(@recipe.description) %>
+    </div>
 
     <div class="recipe-footer">
-            <span class="button-edit-recipe"><%= button_to 'Edit the recipe', edit_recipe_path(@recipe), method: :get, class: "btn-new-search" %></span>
-            <span class="button-edit-recipe"><%= link_to 'Delete the recipe', recipe_path(@recipe), data: {turbo_method: :delete, turbo_confirm: "Are you sure?"}  %></span>
+            <span class="button-edit-recipe"><%= button_to 'Edit this recipe', edit_recipe_path(@recipe), method: :get, class: "btn-new-search" %></span>
+            <span class="link-delete-recipe"><%= link_to 'Delete this recipe', recipe_path(@recipe), data: {turbo_method: :delete, turbo_confirm: "Are you sure?"}  %></span>
     </div>
 
   </div>


### PR DESCRIPTION
The followings are fixed now:
(From Jon's slack post)
2. Rounded edges on recipe images
5. Capitalize ingredient names on shopping list, ingredient cards, etc
6. Remove all the .0 on amounts on recipe ingredients
10. Change "Add" buttons to green instead of pink?
11. Center Recipe search bar on page (appears out of alignment with header on large screens)

And a slight look change on Recipe show page to make the ingredient list not to look like a card.