### PR TITLE
Added 10px margin at the bottom of the navbar.

### DIFF
--- a/app/assets/stylesheets/components/_navigation.scss
+++ b/app/assets/stylesheets/components/_navigation.scss
@@ -38,6 +38,7 @@
 // Icon styles
 .nav-icon {
   margin-top: 10px;
+  margin-bottom: 10px;
   text-decoration: none;
   color: $ft-black;
   transition: transform 0.2s; // Smooth hover effect


### PR DESCRIPTION
I added a 10px margin to the bottom of the navbar since the iPhone's "swipe up indicator" is on the icons, as shown in the attached image.
![image](https://github.com/user-attachments/assets/3e97e2bf-4fe2-4ca6-8707-557df6274e6c)
