### PR TITLE
Margin on the recipe detail page fixed

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -81,7 +81,7 @@ align-items: center;
   border: none;
   border-radius: 15px;
   padding: 10px 20px;
-  font-size: 20px;
+  font-size: 18px;
   cursor: pointer;
   outline: none;
   box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);

--- a/app/assets/stylesheets/components/_recipe_card.scss
+++ b/app/assets/stylesheets/components/_recipe_card.scss
@@ -44,6 +44,7 @@
   display:flex;
   font-size: 20px;
   align-items: center;
+  padding: 10px;
 }
 
 .recipe-content .title {


### PR DESCRIPTION
The margin around the recipe photo and title now fits to the rest of the recipe details.